### PR TITLE
Expands .travis.yml Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,3 @@ before_install:
 script:
   - gulp
 
-matrix:
-  allow_failures:
-    - node_js: 4.0
-    - node_js: 4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
 language: node_js
+
+node_js:
+  - 0.12
+  - 4.0
+  - 4.1
+
 notifications:
   email: false
+
+before_install:
+  - npm install
+
+script:
+  - gulp
+
+matrix:
+  allow_failures:
+    - node_js: 4.0
+    - node_js: 4.1


### PR DESCRIPTION
* Builds against three versions of node
* Allows failure for node 4.0 & node 4.1
    * Note: remove `allow_failures` when the 4.0 and/or 4.1 build passes
* Includes `npm install` explicitly