### PR TITLE
Porting code to node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 0.12
   - 4.0
   - 4.1
+  - 10.6
 
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -55,12 +55,12 @@ C.prototype.save = function (challenge) {
     language: this.language
   }), function (err) { if (err) console.log(err) })
 
-    fs.writeFile(
-        C.paths.challenges + challenge.slug + '.json',
-        JSON.stringify(challenge),
-        function (err) {
-            if (err) console.log(err) 
-        })
+  fs.writeFile(
+    C.paths.challenges + challenge.slug + '.json',
+    JSON.stringify(challenge),
+    function (err) {
+      if (err) console.log(err)
+    })
 }
 
 C.prototype.done = function () {

--- a/index.js
+++ b/index.js
@@ -53,9 +53,14 @@ C.prototype.save = function (challenge) {
     projectId: challenge.projectId,
     solutionId: challenge.solutionId,
     language: this.language
-  }))
+  }), function (err) { if (err) console.log(err) })
 
-  fs.writeFile(C.paths.challenges + challenge.slug + '.json', JSON.stringify(challenge))
+    fs.writeFile(
+        C.paths.challenges + challenge.slug + '.json',
+        JSON.stringify(challenge),
+        function (err) {
+            if (err) console.log(err) 
+        })
 }
 
 C.prototype.done = function () {
@@ -160,7 +165,7 @@ C.prototype.checkCurrentChallenge = function () {
         df.reject()
       }
       if (/^y/.test(answer)) {
-        fs.unlink(currentChallenge)
+        fs.unlink(currentChallenge, function (err) { if (err) console.log(err) })
         df.resolve()
       }
     })

--- a/index.js
+++ b/index.js
@@ -78,7 +78,9 @@ C.prototype.setup = function (opts) {
 
   mkdirp(C.paths.challenges, {}, function (err, made) {
     if (err) throw new Error('Unable to create ~/.config/codewars')
-    fs.writeFile(C.paths.settingsJSON, JSON.stringify(settings))
+    fs.writeFile(C.paths.settingsJSON, JSON.stringify(settings), function (err) {
+      if (err) throw new Error('Unable to create ~/.config/codewars')
+    })
     df.resolve()
   })
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "expect.js": "*",
     "mocha": "^3.5.3",
     "prettyjson": "^1.0.0",
-    "rewire": "*",
+    "rewire": "2.5.2",
     "standard": "^10.0.3"
   },
   "repository": {


### PR DESCRIPTION
A couple of functions fail in node 10 because the callback to some fs functions is now mandatory.

I added a callback when necessary and added node 10.6 as testing target.