### PR TITLE
Do not show 'undefined' when training on an unknown language

### DIFF
--- a/challenge.js
+++ b/challenge.js
@@ -56,10 +56,11 @@ Challenge.prototype.acceptedMessage = function () {
 
 Challenge.prototype.instructions = function () {
   var extension = this.extensions[this.language]
-  var extensionStr = '.' + extension;
+  var extensionStr = '.' + extension
 
-  if (extension == undefined)
-    extensionStr = '';
+  if (extension === undefined) {
+    extensionStr = ''
+  }
 
   return 'To print these instructions again, run: `codewars print`\n' +
   'To verify your solution, run: `codewars verify solution' + extensionStr + '`\n'

--- a/challenge.js
+++ b/challenge.js
@@ -56,9 +56,13 @@ Challenge.prototype.acceptedMessage = function () {
 
 Challenge.prototype.instructions = function () {
   var extension = this.extensions[this.language]
+  var extensionStr = '.' + extension;
+
+  if (extension == undefined)
+    extensionStr = '';
 
   return 'To print these instructions again, run: `codewars print`\n' +
-  'To verify your solution, run: `codewars verify solution.' + extension + '`\n'
+  'To verify your solution, run: `codewars verify solution' + extensionStr + '`\n'
 }
 
 module.exports = function (args) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "expect.js": "*",
     "mocha": "^3.5.3",
     "prettyjson": "^1.0.0",
-    "rewire": "*",
+    "rewire": "2.5.2",
     "standard": "^10.0.3"
   },
   "repository": {


### PR DESCRIPTION
Current code shows:

> To verify your solution, run: `codewars verify solution.undefined

when training on a language it doesn't know the extension for, updating it to show a sensible default instead of undefined.